### PR TITLE
Add configure() function to allow customizing labels

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 
+var config = require('./lib/config');
 var inline = require('./lib/inline');
 var unified = require('./lib/unified');
 
@@ -8,5 +9,12 @@ function printDiff(actual, expected, out) {
 
 printDiff.inline = inline;
 printDiff.unified = unified;
+printDiff.configure = function(newConfig) {
+  if (newConfig && newConfig.labels) {
+    config.labels = newConfig.labels;
+  }
+
+  return printDiff;
+};
 
 module.exports = printDiff;

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    labels: ['expected', 'actual']
+};

--- a/lib/inline.js
+++ b/lib/inline.js
@@ -1,12 +1,13 @@
 
+var config = require('./config');
 var diff = require('diff');
 var color = require('./color');
 
 function legend() {
   return (
     '\n' +
-    color('added', 'expected') + ' ' +
-    color('removed', 'actual') + '\n' +
+    color('added', config.labels[0]) + ' ' +
+    color('removed', config.labels[1]) + '\n' +
     '\n'
   );
 }

--- a/lib/unified.js
+++ b/lib/unified.js
@@ -1,12 +1,13 @@
 
+var config = require('./config');
 var diff = require('diff');
 var color = require('./color');
 
 function legend() {
   return (
     '\n' +
-    color('added', '+ expected') + ' ' +
-    color('removed', '- actual') + '\n' +
+    color('added', '+ ' + config.labels[0]) + ' ' +
+    color('removed', '- ' + config.labels[1]) + '\n' +
     '\n'
   );
 }


### PR DESCRIPTION
A configure() function is added to the main entry point, allowing global configuration of the module.
The only configuration supported is labels to use for the two compared versions, which defaults to 'expected' and 'actual'. The labels are given as an array of the two labels.

The configure function returns the entry point to allow chaining:

```
const printDiff = require('print-diff').configure({labels: ['before', 'after']});
printDiff('Hello\nLinus', 'Hello\nworld')
```

Note, I kept the same javascript version compatibility, i.e., not using const/let/destructuring etc.