### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "test": "mocha"
   },
   "dependencies": {
-    "diff": "^1.2.1"
+    "diff": "^4.0.1"
   },
   "devDependencies": {
-    "mocha": "^2.1.0"
+    "mocha": "^6.2.0"
   }
 }

--- a/test/simple.js
+++ b/test/simple.js
@@ -39,7 +39,7 @@ describe('printDiff.unified', function () {
 
   var result = (
     '\n' + A('+ expected') + ' ' + R('- actual') + '\n' +
-    '\n' + ' Hello\n' + A('+world') + '\n' + R('-Linus') + '\n\n'
+    '\n' + ' Hello\n' + R('-Linus') + '\n' + A('+world') + '\n\n'
   );
 
   it('should print a diff', function (done) {
@@ -72,7 +72,7 @@ describe('printDiff.inline', function () {
 
   var result = (
     '\n' + A('expected') + ' ' + R('actual') + '\n' +
-    '\n' + A('Linus') + R('I') + ' said hello' + '\n\n'
+    '\n' + R('I') + A('Linus') + ' said hello' + '\n\n'
   );
 
   it('should print a diff', function (done) {


### PR DESCRIPTION
`diff` is showing up as a critical risk dependency...

Note: even before updating dependencies I somehow had to modify tests in order to have them pass (+/- lines reversed). Can that be OS-dependent (Mac here)?